### PR TITLE
Example training files

### DIFF
--- a/vortex-ai/ext_es_config.yaml
+++ b/vortex-ai/ext_es_config.yaml
@@ -1,15 +1,15 @@
 workerPoolSpecs:
   machineSpec:
-    machineType: n1-standard-4
-    acceleratorType: NVIDIA_TESLA_P100
-    acceleratorCount: 1
+    machineType: n1-standard-8
+    #acceleratorType: NVIDIA_TESLA_P100
+    #acceleratorCount: 1
   replicaCount: 1
   containerSpec:
     imageUri: europe-west1-docker.pkg.dev/test-cf-411521/argos-repository/argostrain:latest
     # script: entrypoint.sh
-    args:
-      - from=es
-      - to=ext
-      - from_name=Spanish
-      - to_name=Extremaduran
-      - version=1.0
+    #args:
+    #  - from=es
+    #  - to=ext
+    #  - from_name=Spanish
+    #  - to_name=Extremaduran
+    #  - version=1.0

--- a/vortex-ai/runCustomJob.sh
+++ b/vortex-ai/runCustomJob.sh
@@ -2,4 +2,5 @@ gcloud ai custom-jobs create \
   --project=test-cf-411521 \
   --region=europe-west1 \
   --display-name="ArgosTrain for Spanish to Extremaduran" \
-  --config=ext_es_config.yaml
+  --config=ext_es_config.yaml \
+  --command="./entrypoint_es_ext.sh"


### PR DESCRIPTION
Add example training script for Vertex AI. It doesn't work because GCP needs justification to enable GPU training.